### PR TITLE
Barebones JSONAPI Deserializer

### DIFF
--- a/lib/deserializer.rb
+++ b/lib/deserializer.rb
@@ -9,4 +9,5 @@ module Deserializer
   autoload :Attributable,       'deserializer/attributable'
   autoload :Base,               'deserializer/base'
   autoload :DeserializerError,  'deserializer/deserializer_error'
+  autoload :JsonApi,            'deserializer/json_api'
 end

--- a/lib/deserializer/json_api.rb
+++ b/lib/deserializer/json_api.rb
@@ -1,0 +1,17 @@
+module Deserializer
+  class JsonApi < Base
+
+    class << self
+      def from_params(params = {}, &block)
+        data_params = params[:data] || {}
+        id = data_params[:id]
+        type = data_params[:type]
+
+        yield(id, type) if block_given?
+
+        # TODO: account for relationships & links
+        super(data_params[:attributes])
+      end
+    end
+  end
+end

--- a/test/lib/deserializers.rb
+++ b/test/lib/deserializers.rb
@@ -146,3 +146,7 @@ class KeyedHasOneDeserializer < Deserializer::Base
 
   has_one :user_info, deserializer: ::BasicDeserializer, key: :thing
 end
+
+class JsonApiDeserializer < Deserializer::JsonApi
+  attribute :user_info, deserializer: ::BasicDeserializer, key: :thing
+end

--- a/test/unit/deserializer_test.rb
+++ b/test/unit/deserializer_test.rb
@@ -197,4 +197,20 @@ class DeserializerTest < Minitest::Test
     
     assert_equal inherited_permitted_params, InheritedDeserializer.permitted_params
   end
+
+  def test_json_api_yields_block
+    attr_val =  "some user attribute"
+    payload_type = "json_api_type"
+
+    params = { data: { type: payload_type, attributes: { thing: @params } }}
+    expected = { user_info: @params }
+
+    assert_equal(
+      expected,
+      JsonApiDeserializer.from_params( params ) do |id, type|
+        assert_equal nil, id
+        assert_equal payload_type, type
+      end
+    )
+  end
 end


### PR DESCRIPTION
Attempts to lay a barebones foundation for the discussion points in #8 

- the deserializer does not do anything crazy. I figured that adding a `yield` block would give users the flexibility of how they want to interpret the top-level attributes in JSONAPI compliant payloads
- a single test was added
- added a dockerfile & some barebones makefile targets which contain reproducible/portable dev envs (I don't have ruby installed on my host). The `make dev` env will drop you into a docker container with the code in `/workspace`. And the dir that you're running that command in will have all its contents mounted. This way you can develop on your host while running everything in your docker file